### PR TITLE
HB-52: Create Project Query

### DIFF
--- a/backend/controllers/projectController.js
+++ b/backend/controllers/projectController.js
@@ -92,13 +92,13 @@ projects.delete(
 
 //put project
 projects.put(
-  "/:id",
+  "/:project_id",
   validateProjectIdMiddleware,
   validateProjectExistsMiddleware,
   validateProjectStructureMiddleware,
   async (req, res) => {
     try {
-      const update = await updateProject(req.params.id, req.body);
+      const update = await updateProject(req.params.project_id, req.body);
       res.status(200).json(update);
     } catch (error) {
       const statusObj = {

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -89,3 +89,19 @@ CREATE TABLE likes (
     END;     
     $$
     LANGUAGE plpgsql;
+
+
+    CREATE OR REPLACE FUNCTION f_add_project_creator()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        INSERT INTO connections (username, project_id, permissions) VALUES (NEW.creator, NEW.project_id, 'owner');
+        RETURN NULL;
+    END;    
+    $$ 
+    LANGUAGE 'plpgsql';
+
+    CREATE TRIGGER add_project_creator 
+    AFTER INSERT
+    ON projects
+    FOR EACH ROW
+    EXECUTE PROCEDURE f_add_project_creator();

--- a/backend/db/seed.sql
+++ b/backend/db/seed.sql
@@ -18,10 +18,6 @@ INSERT INTO projects(name, details, project_image, archived, creator) VALUES
 ('Legal Drive', 'An illegal racing game that takes place in New York city, where racers can coordinate street racing events using an underground App. This App will track winners and transfer money to participants.', 'https://www.harlemworldmagazine.com/wp-content/uploads/2020/09/The-Fate-Of-The-Furious-64-f3.jpg', false, 'BZ');
 
 INSERT INTO connections (username, project_id, permissions) VALUES
-('RS', 1, 'owner'),
-('JD', 2, 'owner'),
-('DylanL', 3, 'owner'),
-('BZ', 4, 'owner'),
 ('BZ', 2, 'collaborator'),
 ('BZ', 2, 'follow'),
 ('BZ', 3, 'collaborator'),

--- a/backend/helperFunctions/queryHelpers.js
+++ b/backend/helperFunctions/queryHelpers.js
@@ -1,12 +1,13 @@
 const updateProjectQueryBuilder = ({
-  id,
+  project_id,
   name,
   details,
   project_image,
   archived,
+  creator,
 }) => {
-  const variableObj = { name, details, project_image, archived };
-  const queryVariables = [id];
+  const variableObj = { name, details, project_image, archived, creator };
+  const queryVariables = [project_id];
   let varNum = 2;
   let query = [];
 
@@ -15,6 +16,7 @@ const updateProjectQueryBuilder = ({
     details: "string",
     project_image: "string",
     archived: "boolean",
+    creator: "string",
   };
 
   for (let key in variableObj) {

--- a/backend/queries/projectsQueries.js
+++ b/backend/queries/projectsQueries.js
@@ -45,10 +45,6 @@ const createProject = async ({
     "INSERT INTO projects (name, details, project_image, archived, creator) VALUES ($1, $2, $3, $4, $5) RETURNING *",
     [name, details, project_image, archived, creator]
   );
-  await db.one(
-    "INSERT INTO connections (username, project_id, permissions) VALUES ($1, $2, $3) RETURNING *",
-    [newProject.creator, newProject.project_id, "owner"]
-  );
   return newProject;
 };
 
@@ -68,15 +64,16 @@ const deleteProject = async (id) => {
 //input(id, project)
 //output updated project
 const updateProject = async (
-  id,
-  { name, details, project_image, archived }
+  project_id,
+  { name, details, project_image, archived, creator }
 ) => {
   const updateQuery = updateProjectQueryBuilder({
-    id,
+    project_id,
     name,
     details,
     project_image,
     archived,
+    creator,
   });
   //try to update project
   const update = await db.one(


### PR DESCRIPTION
Changes:

- Changed "id" to "project_id" for clarity and middleware compatability purposes in projectController.js, updateProjectQueryBuilder helper function, and updateProject in project queries.
- Added "creator" to updateProject query and updateProjectQueryBuilder helper function to allow for creator to be edited.
- Created function "f_add_project_creator" to insert project creator into our relational table "connections" as owner of their newly created project, utilizing the "NEW" object in schema.sql.
- Added row-level trigger "add_project_creator " to projects table on insert to execute "f_add_project_creator" in schema.sql.
- Removed owner inserts in relational table "connections" from seed.sql (since they'll now be auto populated).
- Removed second SQL insert query from newProject query (since it's not being handled by our new trigger.